### PR TITLE
fix barverify, now using assert.deepEqual

### DIFF
--- a/store-test.js
+++ b/store-test.js
@@ -30,7 +30,7 @@ var barverify = function(bar) {
   assert.equal(new Date(2020,1,1).toISOString(), _.isDate(bar.wen) ? bar.wen.toISOString() : bar.wen )
 
   assert.equal(''+[2,3],''+bar.arr)
-  assert.equal(JSON.stringify({a:1,b:[2],c:{d:3}}),JSON.stringify(bar.obj))
+  assert.deepEqual({a:1,b:[2],c:{d:3}},bar.obj)
 }
 
 


### PR DESCRIPTION
using JSON.stringify the order of serialization/deserialization of the underlying storage counts
