### PR TITLE
Various tests improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,14 +34,15 @@
     "lodash": "^3.10.1"
   },
   "peerDependencies": {
-    "seneca": ">=0.5.0 <0.8.0"
+    "seneca": ">=0.8.0 <0.9.0"
   },
   "devDependencies": {
     "docco": "0.6.3",
     "eslint-config-seneca": "1.x.x",
     "eslint-plugin-hapi": "2.x.x",
     "eslint-plugin-standard": "1.x.x",
+    "lab": "^6.2.0",
     "seneca": "plugin",
-    "lab": "^6.2.0"
+    "seneca-mem-store": "~0.4.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Standard test cases for seneca stores",
   "main": "store-test.js",
   "scripts": {
-    "test": "lab test/*.test.js -r console -v -L -m 3000 -t 80",
+    "test": "lab test/*.test.js -r console -v -L -t 80",
     "annotate": "docco store-test.js -o doc"
   },
   "repository": {
@@ -24,9 +24,8 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "async": "^1.5.0",
-    "chai": "^3.4.1",
-    "nid": "^0.3.2",
+    "async": "^0.9.2",
+    "chai": "^1.9.2",
     "lodash": "^3.10.1"
   },
   "files": [
@@ -35,11 +34,10 @@
     "store-test.js"
   ],
   "devDependencies": {
-    "lab": "^7.3.0",
+    "lab": "^5.16.0",
+    "docco": "0.6.3",
     "eslint-config-seneca": "1.x.x",
     "eslint-plugin-hapi": "2.x.x",
-    "eslint-plugin-standard": "1.x.x",
-    "docco": "0.7.0",
-    "seneca": "~0.7.0"
+    "eslint-plugin-standard": "1.x.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,21 +23,25 @@
     "Mircea Alexandru (https://www.alexandrumircea.ro/)"
   ],
   "license": "MIT",
-  "dependencies": {
-    "async": "^0.9.2",
-    "chai": "^1.9.2",
-    "lodash": "^3.10.1"
-  },
   "files": [
     "README.md",
     "LICENSE.txt",
     "store-test.js"
   ],
+  "dependencies": {
+    "async": "^1.4.0",
+    "chai": "^3.3.0",
+    "lodash": "^3.10.1"
+  },
+  "peerDependencies": {
+    "seneca": ">=0.5.0 <0.8.0"
+  },
   "devDependencies": {
-    "lab": "^5.16.0",
     "docco": "0.6.3",
     "eslint-config-seneca": "1.x.x",
     "eslint-plugin-hapi": "2.x.x",
-    "eslint-plugin-standard": "1.x.x"
+    "eslint-plugin-standard": "1.x.x",
+    "seneca": "plugin",
+    "lab": "^6.2.0"
   }
 }

--- a/store-test.js
+++ b/store-test.js
@@ -89,7 +89,6 @@ function createEntities (si, name, data) {
 
 function basictest (settings) {
   var si = settings.seneca
-  var must_merge = !!settings.must_merge
   var script = settings.script || lab.script()
 
   var describe = script.describe
@@ -242,34 +241,52 @@ function basictest (settings) {
 
         foo.save$(function (err, foo1) {
 
-          try {
-            assert.isNull(err)
-            assert.isNotNull(foo1.id)
-            assert.equal(foo1.id, 'to-be-updated')
-            assert.equal(foo1.p1, 'z1')
-            assert.equal(foo1.p2, 'z2')
-
-            if (must_merge) {
-              assert.equal(foo1.p3, 'v3')
-            }
-
-          } catch (ex) {
-            return done(ex);
-          }
-
+          assert.isNull(err)
+          assert.isNotNull(foo1.id)
+          assert.equal(foo1.id, 'to-be-updated')
+          assert.equal(foo1.p1, 'z1')
+          assert.equal(foo1.p2, 'z2')
+          assert.equal(foo1.p3, 'v3')
 
           foo1.load$('to-be-updated', verify(done, function (foo2) {
             assert.isNotNull(foo2)
             assert.equal(foo2.id, 'to-be-updated')
             assert.equal(foo2.p1, 'z1')
             assert.equal(foo2.p2, 'z2')
+            assert.equal(foo2.p3, 'v3')
 
-            if (must_merge) {
-              assert.equal(foo2.p3, 'v3')
-            }
           }))
 
         })
+      })
+
+      it('should allow to not merge during update with merge$: false', function (done) {
+
+        var foo = si.make({ name$: 'foo' })
+        foo.id = 'to-be-updated'
+        foo.p1 = 'z1'
+        foo.p2 = 'z2'
+
+        foo.save$({ merge$: false }, function (err, foo1) {
+
+          assert.isNull(err)
+          assert.isNotNull(foo1.id)
+          assert.equal(foo1.id, 'to-be-updated')
+          assert.equal(foo1.p1, 'z1')
+          assert.equal(foo1.p2, 'z2')
+          assert.notOk(foo1.p3)
+
+          foo1.load$('to-be-updated', verify(done, function (foo2) {
+            assert.isNotNull(foo2)
+            assert.equal(foo2.id, 'to-be-updated')
+            assert.equal(foo2.p1, 'z1')
+            assert.equal(foo2.p2, 'z2')
+            assert.notOk(foo1.p3)
+
+          }))
+
+        })
+
       })
 
       it('should support different attribute types', function (done) {

--- a/store-test.js
+++ b/store-test.js
@@ -3,8 +3,8 @@
 
 var assert = require('chai').assert
 
-var async = require('async')
-var _ = require('lodash')
+var async    = require('async')
+var _        = require('lodash')
 
 var lab = require('lab')
 
@@ -28,21 +28,19 @@ var bartemplate = {
 }
 
 var barverify = function (bar) {
-  assert.equal('aaa', bar.str)
-  assert.equal(11, bar.int)
-  assert.equal(33.33, bar.dec)
-  assert.equal(false, bar.bol)
-  assert.equal(new Date(2020, 1, 1).toISOString(), _.isDate(bar.wen) ? bar.wen.toISOString() : bar.wen)
-  assert.equal('' + [ 2, 3 ], '' + bar.arr)
-  assert.deepEqual({
+  assert.equal(bar.str, 'aaa')
+  assert.equal(bar.int, 11)
+  assert.equal(bar.dec, 33.33)
+  assert.equal(bar.bol, false)
+  assert.equal(_.isDate(bar.wen) ? bar.wen.toISOString() : bar.wen, new Date(2020, 1, 1).toISOString())
+  assert.equal('' + bar.arr, '' + [ 2, 3 ])
+  assert.deepEqual(bar.obj, {
     a: 1,
     b: [2],
     c: { d: 3 }
-  }, bar.obj)
+  })
 }
 
-
-var scratch = {}
 
 function verify (cb, tests) {
   return function (error, out) {
@@ -66,7 +64,7 @@ function clearDb (si) {
   return function clear (done) {
     async.series([
       function clearFoo (next) {
-        si.make({ name$: 'foo' }).remove$({ all$: true }, next)
+        si.make('foo').remove$({ all$: true }, next)
       },
       function clearBar (next) {
         si.make('zen', 'moon', 'bar').remove$({ all$: true }, next)
@@ -166,7 +164,7 @@ function basictest (settings) {
       })
 
       it('should support different attribute types', function (done) {
-        var bar = si.make({ name$: 'bar', base$: 'moon', zone$: 'zen' })
+        var bar = si.make('zen', 'moon', 'bar')
 
         bar.load$({ str: 'aaa' }, verify(done, function (bar1) {
 
@@ -192,7 +190,7 @@ function basictest (settings) {
 
       it('should save an entity to store (and generate an id)', function (done) {
 
-        var foo = si.make({ name$: 'foo' })
+        var foo = si.make('foo')
         foo.p1 = 'v1'
         foo.p2 = 'v2'
 
@@ -213,7 +211,7 @@ function basictest (settings) {
 
       it('should save an entity to store (with provided id)', function (done) {
 
-        var foo = si.make({ name$: 'foo' })
+        var foo = si.make('foo')
         foo.id$ = 'existing'
         foo.p1 = 'v1'
         foo.p2 = 'v2'
@@ -235,7 +233,7 @@ function basictest (settings) {
 
       it('should update an entity if id provided', function (done) {
 
-        var foo = si.make({ name$: 'foo' })
+        var foo = si.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
@@ -263,7 +261,7 @@ function basictest (settings) {
 
       it('should allow to not merge during update with merge$: false', function (done) {
 
-        var foo = si.make({ name$: 'foo' })
+        var foo = si.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
@@ -315,14 +313,14 @@ function basictest (settings) {
 
       it('should allow dublicate attributes', function (done) {
 
-        var foo = si.make({ name$: 'foo' })
+        var foo = si.make('foo')
         foo.p2 = 'v2'
 
         foo.save$(function (err, foo1) {
 
           assert.isNull(err)
           assert.isNotNull(foo1.id)
-          assert.equal('v2', foo1.p2)
+          assert.equal(foo1.p2, 'v2')
 
           foo.load$(foo1.id, verify(done, function (foo2) {
 
@@ -356,7 +354,7 @@ function basictest (settings) {
 
       it('should update an entity if id provided', function (done) {
 
-        var foo = merge.make({ name$: 'foo' })
+        var foo = merge.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
@@ -384,7 +382,7 @@ function basictest (settings) {
 
       it('should allow to merge during update with merge$: true', function (done) {
 
-        var foo = merge.make({ name$: 'foo' })
+        var foo = merge.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
@@ -461,7 +459,7 @@ function basictest (settings) {
 
         var bar = si.make('zen', 'moon', 'bar')
         bar.list$({ int: bartemplate.int }, verify(done, function (res) {
-          assert.equal(1, res.length)
+          assert.lengthOf(res, 1)
           barverify(res[0])
         }))
 
@@ -667,14 +665,14 @@ function sorttest (settings) {
 
       it('should support ascending order', function (done) {
 
-        var cl = si.make({ name$: 'foo' })
+        var cl = si.make('foo')
         cl.remove$({ sort$: { p1: 1 } }, function (err) {
 
           if (err) {
             return done(err)
           }
 
-          cl.list$({ sort$: { p1: 1 }}, verify(done, function (lst) {
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
             assert.equal(lst.length, 2)
             assert.equal(lst[0].p1, 'v2')
             assert.equal(lst[1].p1, 'v3')
@@ -686,14 +684,14 @@ function sorttest (settings) {
 
       it('should support descending order', function (done) {
 
-        var cl = si.make({ name$: 'foo' })
+        var cl = si.make('foo')
         cl.remove$({ sort$: { p1: -1 } }, function (err) {
 
           if (err) {
             return done(err)
           }
 
-          cl.list$({ sort$: { p1: 1 }}, verify(done, function (lst) {
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
             assert.equal(lst.length, 2)
             assert.equal(lst[0].p1, 'v1')
             assert.equal(lst[1].p1, 'v2')
@@ -729,9 +727,9 @@ function limitstest (settings) {
     ]))
 
     it('check setup correctly', function (done) {
-      var cl = si.make({ name$: 'foo' })
+      var cl = si.make('foo')
       cl.list$({}, verify(done, function (lst) {
-        assert.equal(3, lst.length)
+        assert.lengthOf(lst, 3)
       }))
     })
 
@@ -768,7 +766,7 @@ function limitstest (settings) {
       it('should support limit, skip and sort', function (done) {
         var cl = si.make('foo')
         cl.list$({ limit$: 1, skip$: 1, sort$: { p1: 1 } }, verify(done, function (lst) {
-          assert.equal(1, lst.length)
+          assert.lengthOf(lst, 1)
           assert.equal(lst[0].p1, 'v2')
         }))
       }),
@@ -800,7 +798,7 @@ function limitstest (settings) {
             return done(err)
           }
 
-          cl.list$({ sort$: { p1: 1 }}, verify(done, function (lst) {
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
 
             assert.lengthOf(lst, 2)
             assert.equal(lst[0].p1, 'v1')
@@ -819,7 +817,7 @@ function limitstest (settings) {
             return done(err)
           }
 
-          cl.list$({ sort$: { p1: 1 }}, verify(done, function (lst) {
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
 
             assert.lengthOf(lst, 2)
             assert.equal(lst[0].p1, 'v2')
@@ -838,7 +836,7 @@ function limitstest (settings) {
             return done(err)
           }
 
-          cl.list$({ sort$: { p1: 1 }}, verify(done, function (lst) {
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
 
             assert.lengthOf(lst, 1)
             assert.equal(lst[0].p1, 'v1')
@@ -855,7 +853,7 @@ function limitstest (settings) {
             return done(err)
           }
 
-          cl.list$({ sort$: { p1: 1 }}, verify(done, function (lst) {
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
             assert.lengthOf(lst, 3)
           }))
 
@@ -869,7 +867,7 @@ function limitstest (settings) {
             return done(err)
           }
 
-          cl.list$({ sort$: { p1: 1 }}, verify(done, function (lst) {
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
             assert.lengthOf(lst, 2)
             assert.equal(lst[0].p1, 'v1')
             assert.equal(lst[1].p1, 'v2')
@@ -908,15 +906,15 @@ function sqltest (settings) {
     it('should accept a string query', function (done) {
       Product.list$({ native$: 'SELECT * FROM product ORDER BY price' }, verify(done, function (list) {
 
-        assert.lengthOf(list)
+        assert.lengthOf(list, 2)
 
-        assert.equal('-/-/product', list[0].entity$)
-        assert.equal('apple', list[0].name)
-        assert.equal(100, list[0].price)
+        assert.equal(list[0].entity$, '-/-/product')
+        assert.equal(list[0].name, 'apple')
+        assert.equal(list[0].price, 100)
 
-        assert.equal('-/-/product', list[1].entity$)
-        assert.equal('pear', list[1].name)
-        assert.equal(200, list[1].price)
+        assert.equal(list[1].entity$, '-/-/product')
+        assert.equal(list[1].name, 'pear')
+        assert.equal(list[1].price, 200)
       }))
     })
 
@@ -925,13 +923,14 @@ function sqltest (settings) {
 
         assert.lengthOf(list, 2)
 
-        assert.equal('-/-/product', list[0].entity$)
-        assert.equal('apple', list[0].name)
-        assert.equal(100, list[0].price)
+        assert.equal(list[0].entity$, '-/-/product')
+        assert.equal(list[0].name, 'apple')
+        assert.equal(list[0].price, 100)
 
-        assert.equal('-/-/product', list[1].entity$)
-        assert.equal('pear', list[1].name)
-        assert.equal(200, list[1].price)
+        assert.equal(list[1].entity$, '-/-/product')
+        assert.equal(list[1].name, 'pear')
+        assert.equal(list[1].price, 200)
+
       }))
     })
   })

--- a/store-test.js
+++ b/store-test.js
@@ -605,6 +605,15 @@ function basictest (settings) {
         }))
       })
     })
+
+    describe('Native', function () {
+      it('should prived direct access to the driver', function (done) {
+        var foo = si.make('foo')
+        foo.native$(verify(done, function (driver) {
+          assert.isObject(driver)
+        }))
+      })
+    })
   })
 
   return script

--- a/store-test.js
+++ b/store-test.js
@@ -224,6 +224,31 @@ function basictest (settings) {
         })
       })
 
+      it('should save an entity if id provided but original doesn\'t exist', function (done) {
+        var foo = si.make('foo')
+        foo.id = 'will-be-inserted'
+        foo.p1 = 'z1'
+        foo.p2 = 'z2'
+        foo.p3 = 'z3'
+
+        foo.save$(function (err, foo1) {
+          assert.isNull(err)
+          assert.isNotNull(foo1.id)
+          assert.equal(foo1.id, 'will-be-inserted')
+          assert.equal(foo1.p1, 'z1')
+          assert.equal(foo1.p2, 'z2')
+          assert.equal(foo1.p3, 'z3')
+
+          foo1.load$('to-be-updated', verify(done, function (foo2) {
+            assert.isNotNull(foo2)
+            assert.equal(foo2.id, 'will-be-inserted')
+            assert.equal(foo2.p1, 'z1')
+            assert.equal(foo2.p2, 'z2')
+            assert.equal(foo2.p3, 'z3')
+          }))
+        })
+      })
+
       it('should allow to not merge during update with merge$: false', function (done) {
         var foo = si.make('foo')
         foo.id = 'to-be-updated'

--- a/store-test.js
+++ b/store-test.js
@@ -889,34 +889,26 @@ function sqltest (settings) {
   var script = settings.script || lab.script()
 
   var describe = script.describe
+  var before = script.before
   var it = script.it
 
   var Product = si.make('product')
   describe('Sql support', function () {
     script.before(function before (done) {
-      async.series([
-        function clear (next) {
-          Product.remove$({ all$: true }, next)
-        },
-        function create (next) {
-          var products = [
-            Product.make$({ name: 'apple', price: 100 }),
-            Product.make$({ name: 'pear', price: 200 })
-          ]
 
-          function saveproduct (product, saved) {
-            product.save$(saved)
-          }
+      before(clearDb(si))
+      before(createEntities, 'product', [
+        { name: 'apple', price: 100 },
+        { name: 'pear', price: 200 }
+      ])
 
-          async.forEach(products, saveproduct, next)
-        }
-      ], done)
     })
 
 
     it('should accept a string query', function (done) {
-      Product.list$('SELECT * FROM product ORDER BY price', verify(done, function (list) {
-        assert.equal(2, list.length)
+      Product.list$({ native$: 'SELECT * FROM product ORDER BY price' }, verify(done, function (list) {
+
+        assert.lengthOf(list)
 
         assert.equal('-/-/product', list[0].entity$)
         assert.equal('apple', list[0].name)
@@ -929,8 +921,9 @@ function sqltest (settings) {
     })
 
     it('should accept and array with query and parameters', function (done) {
-      Product.list$([ 'SELECT * FROM product WHERE price >= ? AND price <= ?', 0, 1000 ], verify(done, function (list) {
-        assert.equal(2, list.length)
+      Product.list$({ native$: [ 'SELECT * FROM product WHERE price >= ? AND price <= ?', 0, 1000 ] }, verify(done, function (list) {
+
+        assert.lengthOf(list, 2)
 
         assert.equal('-/-/product', list[0].entity$)
         assert.equal('apple', list[0].name)

--- a/store-test.js
+++ b/store-test.js
@@ -394,7 +394,7 @@ function basictest (settings) {
       })
     })
 
-    describe('With Option marge:false', function () {
+    describe('With Option merge:false', function () {
       beforeEach(clearDb(si))
       beforeEach(createEntities(si, 'foo', [{
         id$: 'to-be-updated',

--- a/store-test.js
+++ b/store-test.js
@@ -445,6 +445,7 @@ function basictest (settings) {
           assert.equal(foo1.p1, 'z1')
           assert.equal(foo1.p2, 'z2')
           assert.equal(foo1.p3, 'v3')
+          assert.notOk(foo1.merge$)
 
           foo1.load$('to-be-updated', verify(done, function (foo2) {
             assert.isNotNull(foo2)
@@ -452,6 +453,7 @@ function basictest (settings) {
             assert.equal(foo2.p1, 'z1')
             assert.equal(foo2.p2, 'z2')
             assert.equal(foo1.p3, 'v3')
+            assert.notOk(foo1.merge$)
           }))
         })
       })

--- a/store-test.js
+++ b/store-test.js
@@ -645,6 +645,30 @@ function limitstest (settings) {
           assert.equal(foo.p1, 'v1')
         }))
       })
+
+      it('should ignore skip < 0', function (done) {
+        var cl = si.make('foo')
+        cl.load$({ skip$: -1, sort$: { p1: 1 } }, verify(done, function (foo) {
+          assert.ok(foo)
+          assert.equal(foo.p1, 'v1')
+        }))
+      })
+
+      it('should ignore limit < 0', function (done) {
+        var cl = si.make('foo')
+        cl.load$({ limit$: -1, sort$: { p1: 1 } }, verify(done, function (foo) {
+          assert.ok(foo)
+          assert.equal(foo.p1, 'v1')
+        }))
+      })
+
+      it('should ignore invalid qualifier values', function (done) {
+        var cl = si.make('foo')
+        cl.load$({ limit$: 'A', skip$: 'B', sort$: { p1: 1 } }, verify(done, function (foo) {
+          assert.ok(foo)
+          assert.equal(foo.p1, 'v1')
+        }))
+      })
     })
 
     describe('List', function () {
@@ -668,6 +692,36 @@ function limitstest (settings) {
         cl.list$({ limit$: 5, skip$: 2, sort$: { p1: 1 } }, verify(done, function (lst) {
           assert.lengthOf(lst, 1)
           assert.equal(lst[0].p1, 'v3')
+        }))
+      })
+
+      it('should ignore skip < 0', function (done) {
+        var cl = si.make('foo')
+        cl.list$({ skip$: -1, sort$: { p1: 1 } }, verify(done, function (lst) {
+          assert.lengthOf(lst, 3)
+          assert.equal(lst[0].p1, 'v1')
+          assert.equal(lst[1].p1, 'v2')
+          assert.equal(lst[2].p1, 'v3')
+        }))
+      })
+
+      it('should ignore limit < 0', function (done) {
+        var cl = si.make('foo')
+        cl.list$({ limit$: -1, sort$: { p1: 1 } }, verify(done, function (lst) {
+          assert.lengthOf(lst, 3)
+          assert.equal(lst[0].p1, 'v1')
+          assert.equal(lst[1].p1, 'v2')
+          assert.equal(lst[2].p1, 'v3')
+        }))
+      })
+
+      it('should ignore invalid qualifier values', function (done) {
+        var cl = si.make('foo')
+        cl.list$({ limit$: 'A', skip$: 'B', sort$: { p1: 1 } }, verify(done, function (lst) {
+          assert.lengthOf(lst, 3)
+          assert.equal(lst[0].p1, 'v1')
+          assert.equal(lst[1].p1, 'v2')
+          assert.equal(lst[2].p1, 'v3')
         }))
       })
     })
@@ -741,6 +795,49 @@ function limitstest (settings) {
             assert.lengthOf(lst, 2)
             assert.equal(lst[0].p1, 'v1')
             assert.equal(lst[1].p1, 'v2')
+          }))
+        })
+      })
+
+      it('should ignore skip < 0', function (done) {
+        var cl = si.make('foo')
+        cl.remove$({ skip$: -1, sort$: { p1: 1 } }, function (err) {
+          if (err) {
+            return done(err)
+          }
+
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
+            assert.lengthOf(lst, 2)
+            assert.equal(lst[0].p1, 'v2')
+            assert.equal(lst[1].p1, 'v3')
+          }))
+        })
+      })
+
+      it('should ignore limit < 0', function (done) {
+        var cl = si.make('foo')
+        cl.remove$({ all$: true, limit$: -1, sort$: { p1: 1 } }, function (err) {
+          if (err) {
+            return done(err)
+          }
+
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
+            assert.lengthOf(lst, 0)
+          }))
+        })
+      })
+
+      it('should ignore invalid qualifier values', function (done) {
+        var cl = si.make('foo')
+        cl.remove$({ limit$: 'A', skip$: 'B', sort$: { p1: 1 } }, function (err) {
+          if (err) {
+            return done(err)
+          }
+
+          cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
+            assert.lengthOf(lst, 2)
+            assert.equal(lst[0].p1, 'v2')
+            assert.equal(lst[1].p1, 'v3')
           }))
         })
       })

--- a/store-test.js
+++ b/store-test.js
@@ -329,8 +329,8 @@ function basictest (settings) {
             assert.isNotNull(foo2)
             assert.equal(foo2.id, foo1.id)
             assert.equal(foo2.p2, 'v2')
-            assert.isUndefined(foo2.p1)
-            assert.isUndefined(foo2.p3)
+            assert.notOk(foo2.p1)
+            assert.notOk(foo2.p3)
 
           }))
 
@@ -451,8 +451,8 @@ function basictest (settings) {
         foo.list$({ id: 'foo1' }, verify(done, function (res) {
           assert.lengthOf(res, 1)
           assert.equal(res[0].p1, 'v1')
-          assert.isUndefined(res[0].p2)
-          assert.isUndefined(res[0].p3)
+          assert.notOk(res[0].p2)
+          assert.notOk(res[0].p3)
         }))
 
       })

--- a/store-test.js
+++ b/store-test.js
@@ -311,6 +311,57 @@ function basictest (settings) {
           }))
         })
       })
+
+      it('should not save modifications to entity after save completes', function (done) {
+        var foo = si.make('foo')
+        foo.p3 = [ 'a' ]
+        foo.save$(verify(done, function (foo1) {
+          assert.deepEqual(foo1.p3, [ 'a' ])
+          // now that foo is in the database, modify the original data
+          foo.p3.push('b')
+          assert.deepEqual(foo1.p3, [ 'a' ])
+        }))
+      })
+
+      it('should not backport modification to saved entity to the original one', function (done) {
+        var foo = si.make('foo')
+        foo.p3 = [ 'a' ]
+        foo.save$(verify(done, function (foo1) {
+          assert.deepEqual(foo1.p3, [ 'a' ])
+          // now that foo is in the database, modify the original data
+          foo1.p3.push('b')
+          assert.deepEqual(foo.p3, [ 'a' ])
+        }))
+      })
+
+      it('should clear an attribute if = null', function (done) {
+        var foo = si.make('foo')
+        foo.p1 = 'v1'
+        foo.p2 = 'v2'
+
+        foo.save$(function (err, foo1) {
+          if (err) {
+            return done(err)
+          }
+
+          foo1.p1 = null
+          foo1.p2 = undefined
+          foo1.save$(function (err, foo2) {
+            if (err) {
+              return done(err)
+            }
+
+            assert.notOk(foo2.p1)
+            assert.notOk(foo2.p2)
+
+            foo.load$(foo1.id, verify(done, function (foo3) {
+              assert.ok(foo3)
+              assert.notOk(foo3.p1)
+              assert.notOk(foo3.p2)
+            }))
+          })
+        })
+      })
     })
 
     describe('With Option marge:false', function () {

--- a/store-test.js
+++ b/store-test.js
@@ -151,6 +151,17 @@ function basictest (settings) {
           barverify(bar1)
         }))
       })
+
+      it('should not mix attributes from entity to query for filtering', function (done) {
+        var foo = si.make('foo')
+        foo.p1 = 'v1'
+        foo.load$({ p2: 'z2' }, verify(done, function (foo1) {
+          assert.ok(foo1)
+          assert.equal(foo1.id, 'foo2')
+          assert.equal(foo1.p1, 'v2')
+          assert.equal(foo1.p2, 'z2')
+        }))
+      })
     })
 
     describe('Save', function () {
@@ -529,6 +540,17 @@ function basictest (settings) {
           assert.lengthOf(res, 0)
         }))
       })
+
+      it('should not mix attributes from entity to query for filtering', function (done) {
+        var foo = si.make('foo')
+        foo.p1 = 'v1'
+        foo.list$({ p2: 'z2' }, verify(done, function (res) {
+          assert.lengthOf(res, 1)
+          assert.equal(res[0].id, 'foo2')
+          assert.equal(res[0].p1, 'v2')
+          assert.equal(res[0].p2, 'z2')
+        }))
+      })
     })
 
     describe('Remove', function () {
@@ -603,6 +625,21 @@ function basictest (settings) {
         foo.remove$({ all$: true, load$: true }, verify(done, function (res) {
           assert.notOk(res)
         }))
+      })
+
+      it('should not delete current env (only uses query)', function (done) {
+        var foo = si.make('foo')
+        foo.id = 'foo2'
+        foo.remove$({ p1: 'v1' }, function (err) {
+          if (err) {
+            return done(err)
+          }
+
+          foo.list$(verify(done, function (res) {
+            assert.lengthOf(res, 1)
+            assert.equal(res[0].id, 'foo2')
+          }))
+        })
       })
     })
 

--- a/store-test.js
+++ b/store-test.js
@@ -250,7 +250,7 @@ function basictest (settings) {
           assert.equal(foo1.p2, 'z2')
           assert.equal(foo1.p3, 'z3')
 
-          foo1.load$('to-be-updated', verify(done, function (foo2) {
+          foo1.load$('will-be-inserted', verify(done, function (foo2) {
             assert.isNotNull(foo2)
             assert.equal(foo2.id, 'will-be-inserted')
             assert.equal(foo2.p1, 'z1')

--- a/store-test.js
+++ b/store-test.js
@@ -487,12 +487,11 @@ function basictest (settings) {
 
       })
 
-      it('should return only first deleted entity if load$: true', function (done) {
+      it('should never return deleted entities if all$: true', function (done) {
 
         var foo = si.make('foo')
         foo.remove$({ all$: true, load$: true }, verify(done, function (res) {
-          assert.ok(res)
-          assert.equal(res.p1, 'v1')
+          assert.notOk(res)
         }))
 
       })

--- a/store-test.js
+++ b/store-test.js
@@ -163,14 +163,22 @@ function basictest (settings) {
         }))
       })
 
-      it('should reload current entity if no query provided', function (done) {
+      it('should reload current entity if no query provided and id present', function (done) {
         var foo = si.make('foo')
-        foo.p1 = 'v2'
+        foo.id = 'foo2'
         foo.load$(verify(done, function (foo1) {
           assert.ok(foo1)
           assert.equal(foo1.id, 'foo2')
           assert.equal(foo1.p1, 'v2')
           assert.equal(foo1.p2, 'z2')
+        }))
+      })
+
+      it('should do nothing if no query provided and id not present', function (done) {
+        var foo = si.make('foo')
+        foo.p1 = 'v2'
+        foo.load$(verify(done, function (foo1) {
+          assert.notOk(foo1)
         }))
       })
     })

--- a/store-test.js
+++ b/store-test.js
@@ -439,6 +439,39 @@ function basictest (settings) {
         }))
       })
 
+      it('should support opaque ids (array)', function (done) {
+        var foo = si.make('foo')
+        foo.list$([ 'foo1', 'foo2' ], verify(done, function (res) {
+          assert.lengthOf(res, 2)
+          assert.equal(res[0].p1, 'v1')
+          assert.notOk(res[0].p2)
+          assert.notOk(res[0].p3)
+          assert.equal(res[1].p1, 'v2')
+          assert.equal(res[1].p2, 'z2')
+          assert.equal(res[1].p3)
+        }))
+      })
+
+      it('should support opaque ids (single id)', function (done) {
+        var foo = si.make('foo')
+        foo.list$([ 'foo2' ], verify(done, function (res) {
+          assert.lengthOf(res, 1)
+          assert.equal(res[0].p1, 'v2')
+          assert.equal(res[0].p2, 'z2')
+          assert.equal(res[0].p3)
+        }))
+      })
+
+      it('should support opaque ids (string)', function (done) {
+        var foo = si.make('foo')
+        foo.list$('foo2', verify(done, function (res) {
+          assert.lengthOf(res, 1)
+          assert.equal(res[0].p1, 'v2')
+          assert.equal(res[0].p2, 'z2')
+          assert.equal(res[0].p3)
+        }))
+      })
+
       it('should filter with AND', function (done) {
         var foo = si.make('foo')
         foo.list$({ p2: 'z2', p1: 'v1' }, verify(done, function (res) {

--- a/store-test.js
+++ b/store-test.js
@@ -162,6 +162,17 @@ function basictest (settings) {
           assert.equal(foo1.p2, 'z2')
         }))
       })
+
+      it('should reload current entity if no query provided', function (done) {
+        var foo = si.make('foo')
+        foo.p1 = 'v2'
+        foo.load$(verify(done, function (foo1) {
+          assert.ok(foo1)
+          assert.equal(foo1.id, 'foo2')
+          assert.equal(foo1.p1, 'v2')
+          assert.equal(foo1.p2, 'z2')
+        }))
+      })
     })
 
     describe('Save', function () {
@@ -465,6 +476,13 @@ function basictest (settings) {
         }))
       })
 
+      it('should load all elements if no query provided', function (done) {
+        var foo = si.make('foo')
+        foo.list$(verify(done, function (res) {
+          assert.lengthOf(res, 2)
+        }))
+      })
+
       it('should list entities by id', function (done) {
         var foo = si.make('foo')
         foo.list$({ id: 'foo1' }, verify(done, function (res) {
@@ -627,7 +645,7 @@ function basictest (settings) {
         }))
       })
 
-      it('should not delete current env (only uses query)', function (done) {
+      it('should not delete current ent (only uses query)', function (done) {
         var foo = si.make('foo')
         foo.id = 'foo2'
         foo.remove$({ p1: 'v1' }, function (err) {
@@ -639,6 +657,24 @@ function basictest (settings) {
             assert.lengthOf(res, 1)
             assert.equal(res[0].id, 'foo2')
           }))
+        })
+      })
+
+      it('should delete current entity if no query present', function (done) {
+        var foo = si.make$('foo')
+        foo.load$('foo2', function (err, foo2) {
+          if (err) {
+            return done(err)
+          }
+          foo2.remove$(function (err) {
+            if (err) {
+              return done(err)
+            }
+            foo.list$({}, verify(done, function (res) {
+              assert.lengthOf(res, 1)
+              assert.equal(res[0].id, 'foo1')
+            }))
+          })
         })
       })
     })

--- a/store-test.js
+++ b/store-test.js
@@ -2,12 +2,9 @@
 'use strict'
 
 var assert = require('chai').assert
-
-var async    = require('async')
-var _        = require('lodash')
-
+var async = require('async')
+var _ = require('lodash')
 var lab = require('lab')
-
 
 var bartemplate = {
   name$: 'bar',
@@ -41,7 +38,6 @@ var barverify = function (bar) {
   })
 }
 
-
 function verify (cb, tests) {
   return function (error, out) {
     if (error) {
@@ -59,7 +55,6 @@ function verify (cb, tests) {
   }
 }
 
-
 function clearDb (si) {
   return function clear (done) {
     async.series([
@@ -74,15 +69,11 @@ function clearDb (si) {
 }
 
 function createEntities (si, name, data) {
-
   return function create (done) {
-
     async.each(data, function (el, next) {
       si.make$(name, el).save$(next)
     }, done)
-
   }
-
 }
 
 function basictest (settings) {
@@ -96,9 +87,7 @@ function basictest (settings) {
   var beforeEach = script.beforeEach
 
   describe('Basic Tests', function () {
-
     describe('Load', function () {
-
       before(clearDb(si))
       before(createEntities(si, 'foo', [{
         id$: 'foo1',
@@ -111,27 +100,22 @@ function basictest (settings) {
       before(createEntities(si, 'bar', [ bartemplate ]))
 
       it('should load an entity', function (done) {
-
         var foo = si.make('foo')
         foo.load$('foo1', verify(done, function (foo1) {
           assert.isNotNull(foo1)
           assert.equal(foo1.id, 'foo1')
           assert.equal(foo1.p1, 'v1')
         }))
-
       })
 
       it('should return null for non existing entity', function (done) {
-
         var foo = si.make('foo')
         foo.load$('does-not-exist-at-all-at-all', verify(done, function (out) {
           assert.isNull(out)
         }))
-
       })
 
       it('should support filtering', function (done) {
-
         var foo = si.make('foo')
         foo.load$({ p1: 'v2' }, verify(done, function (foo1) {
           assert.isNotNull(foo1)
@@ -139,11 +123,9 @@ function basictest (settings) {
           assert.equal(foo1.p1, 'v2')
           assert.equal(foo1.p2, 'z2')
         }))
-
       })
 
       it('should filter with AND', function (done) {
-
         var foo = si.make('foo')
         foo.load$({ p1: 'v2', p2: 'z2' }, verify(done, function (foo1) {
           assert.isNotNull(foo1)
@@ -151,35 +133,27 @@ function basictest (settings) {
           assert.equal(foo1.p1, 'v2')
           assert.equal(foo1.p2, 'z2')
         }))
-
       })
 
       it('should filter with AND 2', function (done) {
-
         var foo = si.make('foo')
         foo.load$({ p1: 'v2', p2: 'a' }, verify(done, function (foo1) {
           assert.isNull(foo1)
         }))
-
       })
 
       it('should support different attribute types', function (done) {
         var bar = si.make('zen', 'moon', 'bar')
 
         bar.load$({ str: 'aaa' }, verify(done, function (bar1) {
-
           assert.isNotNull(bar1)
           assert.isNotNull(bar1.id)
           barverify(bar1)
-
         }))
-
       })
-
     })
 
     describe('Save', function () {
-
       beforeEach(clearDb(si))
       beforeEach(createEntities(si, 'foo', [{
         id$: 'to-be-updated',
@@ -189,7 +163,6 @@ function basictest (settings) {
       }]))
 
       it('should save an entity to store (and generate an id)', function (done) {
-
         var foo = si.make('foo')
         foo.p1 = 'v1'
         foo.p2 = 'v2'
@@ -198,19 +171,16 @@ function basictest (settings) {
           assert.isNull(err)
           assert.isNotNull(foo1.id)
 
-
           foo1.load$(foo1.id, verify(done, function (foo2) {
             assert.isNotNull(foo2)
             assert.equal(foo2.id, foo1.id)
             assert.equal(foo2.p1, 'v1')
             assert.equal(foo2.p2, 'v2')
           }))
-
         })
       })
 
       it('should save an entity to store (with provided id)', function (done) {
-
         var foo = si.make('foo')
         foo.id$ = 'existing'
         foo.p1 = 'v1'
@@ -227,19 +197,16 @@ function basictest (settings) {
             assert.equal(foo2.p1, 'v1')
             assert.equal(foo2.p2, 'v2')
           }))
-
         })
       })
 
       it('should update an entity if id provided', function (done) {
-
         var foo = si.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
 
         foo.save$(function (err, foo1) {
-
           assert.isNull(err)
           assert.isNotNull(foo1.id)
           assert.equal(foo1.id, 'to-be-updated')
@@ -253,21 +220,17 @@ function basictest (settings) {
             assert.equal(foo2.p1, 'z1')
             assert.equal(foo2.p2, 'z2')
             assert.equal(foo2.p3, 'v3')
-
           }))
-
         })
       })
 
       it('should allow to not merge during update with merge$: false', function (done) {
-
         var foo = si.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
 
         foo.save$({ merge$: false }, function (err, foo1) {
-
           assert.isNull(err)
           assert.isNotNull(foo1.id)
           assert.equal(foo1.id, 'to-be-updated')
@@ -281,11 +244,8 @@ function basictest (settings) {
             assert.equal(foo2.p1, 'z1')
             assert.equal(foo2.p2, 'z2')
             assert.notOk(foo1.p3)
-
           }))
-
         })
-
       })
 
       it('should support different attribute types', function (done) {
@@ -300,45 +260,35 @@ function basictest (settings) {
           assert.equal(bar.mark, mark)
 
           bar.load$(bar.id, verify(done, function (bar1) {
-
             assert.isNotNull(bar1)
             assert.equal(bar1.id, bar.id)
             barverify(bar1)
             assert.equal(bar1.mark, mark)
-
           }))
-
         })
       })
 
       it('should allow dublicate attributes', function (done) {
-
         var foo = si.make('foo')
         foo.p2 = 'v2'
 
         foo.save$(function (err, foo1) {
-
           assert.isNull(err)
           assert.isNotNull(foo1.id)
           assert.equal(foo1.p2, 'v2')
 
           foo.load$(foo1.id, verify(done, function (foo2) {
-
             assert.isNotNull(foo2)
             assert.equal(foo2.id, foo1.id)
             assert.equal(foo2.p2, 'v2')
             assert.notOk(foo2.p1)
             assert.notOk(foo2.p3)
-
           }))
-
         })
       })
-
     })
 
     describe('With Option marge:false', function () {
-
       beforeEach(clearDb(si))
       beforeEach(createEntities(si, 'foo', [{
         id$: 'to-be-updated',
@@ -348,19 +298,17 @@ function basictest (settings) {
       }]))
 
       it('should provide senecaMerge', function (done) {
-        assert(merge, "Implementor should provide a seneca instance with the store configured to default to merge:false")
+        assert(merge, 'Implementor should provide a seneca instance with the store configured to default to merge:false')
         done()
       })
 
       it('should update an entity if id provided', function (done) {
-
         var foo = merge.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
 
         foo.save$(function (err, foo1) {
-
           assert.isNull(err)
           assert.isNotNull(foo1.id)
           assert.equal(foo1.id, 'to-be-updated')
@@ -374,21 +322,17 @@ function basictest (settings) {
             assert.equal(foo2.p1, 'z1')
             assert.equal(foo2.p2, 'z2')
             assert.notOk(foo2.p3)
-
           }))
-
         })
       })
 
       it('should allow to merge during update with merge$: true', function (done) {
-
         var foo = merge.make('foo')
         foo.id = 'to-be-updated'
         foo.p1 = 'z1'
         foo.p2 = 'z2'
 
         foo.save$({ merge$: true }, function (err, foo1) {
-
           assert.isNull(err)
           assert.isNotNull(foo1.id)
           assert.equal(foo1.id, 'to-be-updated')
@@ -402,17 +346,12 @@ function basictest (settings) {
             assert.equal(foo2.p1, 'z1')
             assert.equal(foo2.p2, 'z2')
             assert.equal(foo1.p3, 'v3')
-
           }))
-
         })
-
       })
-
-  })
+    })
 
     describe('List', function () {
-
       before(clearDb(si))
       before(createEntities(si, 'foo', [{
         id$: 'foo1',
@@ -425,26 +364,21 @@ function basictest (settings) {
       before(createEntities(si, 'bar', [ bartemplate ]))
 
       it('should load all elements if no params', function (done) {
-
         var bar = si.make('zen', 'moon', 'bar')
         bar.list$({}, verify(done, function (res) {
           assert.lengthOf(res, 1)
           barverify(res[0])
         }))
-
       })
 
       it('should load all elements if no params 2', function (done) {
-
-        var foo = si.make('foo');
+        var foo = si.make('foo')
         foo.list$({}, verify(done, function (res) {
           assert.lengthOf(res, 2)
         }))
-
       })
 
       it('should list entities by id', function (done) {
-
         var foo = si.make('foo')
         foo.list$({ id: 'foo1' }, verify(done, function (res) {
           assert.lengthOf(res, 1)
@@ -452,22 +386,18 @@ function basictest (settings) {
           assert.notOk(res[0].p2)
           assert.notOk(res[0].p3)
         }))
-
       })
 
       it('should list entities by integer property', function (done) {
-
         var bar = si.make('zen', 'moon', 'bar')
         bar.list$({ int: bartemplate.int }, verify(done, function (res) {
           assert.lengthOf(res, 1)
           barverify(res[0])
         }))
-
       })
 
       it('should list entities by string property', function (done) {
-
-        var foo = si.make('foo');
+        var foo = si.make('foo')
         foo.list$({ p2: 'z2' }, verify(done, function (res) {
           assert.lengthOf(res, 1)
           assert.equal(res[0].p1, 'v2')
@@ -476,29 +406,23 @@ function basictest (settings) {
       })
 
       it('should list entities by two properties', function (done) {
-
         var foo = si.make('foo')
         foo.list$({ p2: 'z2', p1: 'v2' }, verify(done, function (res) {
           assert.lengthOf(res, 1)
           assert.equal(res[0].p1, 'v2')
           assert.equal(res[0].p2, 'z2')
         }))
-
       })
 
       it('should filter with AND', function (done) {
-
         var foo = si.make('foo')
         foo.list$({ p2: 'z2', p1: 'v1' }, verify(done, function (res) {
           assert.lengthOf(res, 0)
         }))
-
       })
-
     })
 
     describe('Remove', function () {
-
       beforeEach(clearDb(si))
       beforeEach(createEntities(si, 'foo', [{
         id$: 'foo1',
@@ -511,10 +435,8 @@ function basictest (settings) {
       beforeEach(createEntities(si, 'bar', [ bartemplate ]))
 
       it('should delete only an entity', function (done) {
-
         var foo = si.make('foo')
         foo.remove$({}, function (err, res) {
-
           assert.isNull(err)
           assert.notOk(res)
 
@@ -522,14 +444,11 @@ function basictest (settings) {
             assert.lengthOf(res, 1)
           }))
         })
-
       })
 
       it('should delete all entities if all$ = true', function (done) {
-
         var foo = si.make('foo')
         foo.remove$({ all$: true }, function (err, res) {
-
           assert.isNull(err)
           assert.notOk(res)
 
@@ -537,11 +456,9 @@ function basictest (settings) {
             assert.lengthOf(res, 0)
           }))
         })
-
       })
 
       it('should delete an entity by property', function (done) {
-
         var bar = si.make('bar')
         bar.remove$({ int: bartemplate.int }, function (err, res) {
           assert.isNull(err)
@@ -550,11 +467,9 @@ function basictest (settings) {
             assert.lengthOf(res, 0)
           }))
         })
-
       })
 
       it('should delete entities filtered by AND', function (done) {
-
         var foo = si.make('foo')
         foo.remove$({ p1: 'v1', p2: 'z2' }, function (err) {
           assert.isNull(err)
@@ -563,27 +478,22 @@ function basictest (settings) {
             assert.lengthOf(res, 2)
           }))
         })
-
       })
 
       it('should return deleted entity if load$: true', function (done) {
-
         var foo = si.make('foo')
         foo.remove$({ p1: 'v2', load$: true }, verify(done, function (res) {
           assert.ok(res)
           assert.equal(res.p1, 'v2')
           assert.equal(res.p2, 'z2')
         }))
-
       })
 
       it('should never return deleted entities if all$: true', function (done) {
-
         var foo = si.make('foo')
         foo.remove$({ all$: true, load$: true }, verify(done, function (res) {
           assert.notOk(res)
         }))
-
       })
     })
   })
@@ -600,7 +510,6 @@ function sorttest (settings) {
   var beforeEach = script.beforeEach
 
   describe('Sorting', function () {
-
     beforeEach(clearDb(si))
     beforeEach(createEntities(si, 'foo', [
       { p1: 'v1', p2: 'v1' },
@@ -612,32 +521,25 @@ function sorttest (settings) {
     ]))
 
     describe('Load', function () {
-
       it('should support ascending order', function (done) {
-
         var cl = si.make('foo')
         cl.load$({ sort$: { p1: 1 } }, verify(done, function (foo) {
           assert.ok(foo)
           assert.equal(foo.p1, 'v1')
         }))
-
       })
 
       it('should support descending order', function (done) {
-
         var cl = si.make('foo')
         cl.load$({ sort$: { p1: -1 } }, verify(done, function (foo) {
           assert.ok(foo)
           assert.equal(foo.p1, 'v3')
         }))
       })
-
     })
 
     describe('List', function () {
-
       it('should support ascending order', function (done) {
-
         var cl = si.make('foo')
         cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
           assert.lengthOf(lst, 3)
@@ -645,11 +547,9 @@ function sorttest (settings) {
           assert.equal(lst[1].p1, 'v2')
           assert.equal(lst[2].p1, 'v3')
         }))
-
       })
 
       it('should support descending order', function (done) {
-
         var cl = si.make('foo')
         cl.list$({ sort$: { p1: -1 } }, verify(done, function (lst) {
           assert.lengthOf(lst, 3)
@@ -658,16 +558,12 @@ function sorttest (settings) {
           assert.equal(lst[2].p1, 'v1')
         }))
       })
-
     })
 
     describe('Remove', function () {
-
       it('should support ascending order', function (done) {
-
         var cl = si.make('foo')
         cl.remove$({ sort$: { p1: 1 } }, function (err) {
-
           if (err) {
             return done(err)
           }
@@ -677,16 +573,12 @@ function sorttest (settings) {
             assert.equal(lst[0].p1, 'v2')
             assert.equal(lst[1].p1, 'v3')
           }))
-
         })
-
       })
 
       it('should support descending order', function (done) {
-
         var cl = si.make('foo')
         cl.remove$({ sort$: { p1: -1 } }, function (err) {
-
           if (err) {
             return done(err)
           }
@@ -696,10 +588,8 @@ function sorttest (settings) {
             assert.equal(lst[0].p1, 'v1')
             assert.equal(lst[1].p1, 'v2')
           }))
-
         })
       })
-
     })
   })
 
@@ -715,7 +605,6 @@ function limitstest (settings) {
   var beforeEach = script.beforeEach
 
   describe('Limits', function () {
-
     beforeEach(clearDb(si))
     beforeEach(createEntities(si, 'foo', [
       { p1: 'v1' },
@@ -733,15 +622,14 @@ function limitstest (settings) {
       }))
     })
 
-    describe("Load", function () {
-
+    describe('Load', function () {
       it('should support skip and sort', function (done) {
         var cl = si.make('foo')
         cl.load$({ skip$: 1, sort$: { p1: 1 } }, verify(done, function (foo) {
           assert.ok(foo)
           assert.equal(foo.p1, 'v2')
         }))
-      }),
+      })
 
       it('should return empty array when skipping all the records', function (done) {
         var cl = si.make('foo')
@@ -757,19 +645,16 @@ function limitstest (settings) {
           assert.equal(foo.p1, 'v1')
         }))
       })
-
     })
 
-
-    describe("List", function () {
-
+    describe('List', function () {
       it('should support limit, skip and sort', function (done) {
         var cl = si.make('foo')
         cl.list$({ limit$: 1, skip$: 1, sort$: { p1: 1 } }, verify(done, function (lst) {
           assert.lengthOf(lst, 1)
           assert.equal(lst[0].p1, 'v2')
         }))
-      }),
+      })
 
       it('should return empty array when skipping all the records', function (done) {
         var cl = si.make('foo')
@@ -785,64 +670,50 @@ function limitstest (settings) {
           assert.equal(lst[0].p1, 'v3')
         }))
       })
-
     })
 
-    describe("Remove", function () {
-
+    describe('Remove', function () {
       it('should support limit, skip and sort', function (done) {
         var cl = si.make('foo')
         cl.remove$({ limit$: 1, skip$: 1, sort$: { p1: 1 } }, function (err) {
-
           if (err) {
             return done(err)
           }
 
           cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
-
             assert.lengthOf(lst, 2)
             assert.equal(lst[0].p1, 'v1')
             assert.equal(lst[1].p1, 'v3')
-
           }))
         })
-
       })
 
       it('should not be impacted by limit > 1', function (done) {
         var cl = si.make('foo')
         cl.remove$({ limit$: 2, sort$: { p1: 1 } }, function (err) {
-
           if (err) {
             return done(err)
           }
 
           cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
-
             assert.lengthOf(lst, 2)
             assert.equal(lst[0].p1, 'v2')
             assert.equal(lst[1].p1, 'v3')
-
           }))
-
         })
       })
 
       it('should work with all$: true', function (done) {
         var cl = si.make('foo')
         cl.remove$({ all$: true, limit$: 2, skip$: 1, sort$: { p1: 1 } }, function (err) {
-
           if (err) {
             return done(err)
           }
 
           cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
-
             assert.lengthOf(lst, 1)
             assert.equal(lst[0].p1, 'v1')
-
           }))
-
         })
       })
 
@@ -856,7 +727,6 @@ function limitstest (settings) {
           cl.list$({ sort$: { p1: 1 } }, verify(done, function (lst) {
             assert.lengthOf(lst, 3)
           }))
-
         })
       })
 
@@ -872,10 +742,8 @@ function limitstest (settings) {
             assert.equal(lst[0].p1, 'v1')
             assert.equal(lst[1].p1, 'v2')
           }))
-
         })
       })
-
     })
   })
 
@@ -892,20 +760,16 @@ function sqltest (settings) {
 
   var Product = si.make('product')
   describe('Sql support', function () {
-    script.before(function before (done) {
-
+    before(function before (done) {
       before(clearDb(si))
       before(createEntities, 'product', [
         { name: 'apple', price: 100 },
         { name: 'pear', price: 200 }
       ])
-
     })
-
 
     it('should accept a string query', function (done) {
       Product.list$({ native$: 'SELECT * FROM product ORDER BY price' }, verify(done, function (list) {
-
         assert.lengthOf(list, 2)
 
         assert.equal(list[0].entity$, '-/-/product')
@@ -920,7 +784,6 @@ function sqltest (settings) {
 
     it('should accept and array with query and parameters', function (done) {
       Product.list$({ native$: [ 'SELECT * FROM product WHERE price >= ? AND price <= ?', 0, 1000 ] }, verify(done, function (list) {
-
         assert.lengthOf(list, 2)
 
         assert.equal(list[0].entity$, '-/-/product')
@@ -930,7 +793,6 @@ function sqltest (settings) {
         assert.equal(list[1].entity$, '-/-/product')
         assert.equal(list[1].name, 'pear')
         assert.equal(list[1].price, 200)
-
       }))
     })
   })

--- a/store-test.js
+++ b/store-test.js
@@ -395,8 +395,8 @@ function basictest (settings) {
     })
 
     describe('With Option merge:false', function () {
-      beforeEach(clearDb(si))
-      beforeEach(createEntities(si, 'foo', [{
+      beforeEach(clearDb(merge))
+      beforeEach(createEntities(merge, 'foo', [{
         id$: 'to-be-updated',
         p1: 'v1',
         p2: 'v2',

--- a/test.sh
+++ b/test.sh
@@ -1,4 +1,0 @@
-if [ ! -d "./node_modules/seneca" ]; then
-  npm install seneca
-fi
-./node_modules/.bin/lab test/*.test.js -r console -v

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -9,9 +9,12 @@ var Lab = require('lab')
 var lab = exports.lab = Lab.script()
 
 var si = seneca({log: 'silent'})
+var merge = seneca({log: 'silent'})
+merge.use('mem-store', { merge: true })
 
 shared.basictest({
   seneca: si,
+  senecaMerge: merge,
   script: lab
 })
 

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -1,15 +1,15 @@
 /* Copyright (c) 2014 Richard Rodger, MIT License */
 'use strict'
 
-
 var seneca = require('seneca')
 var shared = require('..')
 
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
 
-var si = seneca({log: 'silent'})
-var merge = seneca({log: 'silent'})
+
+var si = seneca({ log: 'silent' })
+var merge = seneca({ log: 'silent' })
 merge.use('mem-store', { merge: true })
 
 shared.basictest({

--- a/test/store.test.js
+++ b/test/store.test.js
@@ -2,15 +2,23 @@
 'use strict'
 
 var seneca = require('seneca')
+var memStore = require('seneca-mem-store')
 var shared = require('..')
 
 var Lab = require('lab')
 var lab = exports.lab = Lab.script()
 
+var si = seneca({
+  log: 'silent',
+  default_plugins: { 'mem-store': false }
+})
+si.use(memStore)
 
-var si = seneca({ log: 'silent' })
-var merge = seneca({ log: 'silent' })
-merge.use('mem-store', { merge: true })
+var merge = seneca({
+  log: 'silent',
+  default_plugins: { 'mem-store': false }
+})
+merge.use(memStore, { merge: false })
 
 shared.basictest({
   seneca: si,


### PR DESCRIPTION
This PR includes:
- make tests self contained, thus order independent
- expand tests to fully cover specs as per https://github.com/rjrodger/seneca/blob/master/doc/data-store.md#cmdremove and discussions in the following issues: https://github.com/rjrodger/seneca-store-test/issues/13, https://github.com/rjrodger/seneca-store-test/issues/14, https://github.com/rjrodger/seneca-store-test/issues/15, https://github.com/rjrodger/seneca-store-test/issues/16 and https://github.com/rjrodger/seneca-store-test/issues/17
- adhere to "standard" style adopted for all seneca related repos
- bring dependencies up to date

This PR does not include:
- updates to the README
- version bump
- wrapped errors as discussed in https://github.com/rjrodger/seneca-store-test/issues/14 (I'm working on an additional PR to bring that, but would like to get this merged first)

Notes:
- instead of relying on test.sh to install seneca I added it to devDependencies. I'm not 100% sure it's the right place
- this will require an update to how tests are run on the stores, since it now requires a "senecaMerge" option. That should be an instance of seneca with the store configured with the merge option set to false
- tested with seneca from 0.5 to 0.7, node 0.10, 0.12, 4, 4.1
- mem-store included with seneca fails some of the tests